### PR TITLE
Fix: Remove .dockerignore patterns blocking docker-compose files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,4 @@ integration-test-results
 integration-test-output.log
 *.tmp
 .DS_Store
-docker-compose*.yml
-Dockerfile*
 .dockerignore


### PR DESCRIPTION
### **User description**
## Problem
The docker-compose-config.test.ts test is failing with:
```
ENOENT: no such file or directory, open '/app/docker-compose.integration.yml'
```

## Root Cause
While PR #6 added `COPY docker-compose*.yml ./` to the Dockerfile, the .dockerignore file was still blocking these patterns:
- `docker-compose*.yml`
- `Dockerfile*`

This prevented the files from being copied into the Docker image.

## Solution
Removed the blocking patterns from .dockerignore so docker-compose configuration files can be copied into the test container.

## Testing
After this fix, the docker-compose-config.test.ts tests should pass because docker-compose.integration.yml will be available in the container at /app/docker-compose.integration.yml.

## Related
- Completes the fix started in PR #6
- Resolves test failures in Integration Tests CI workflow


___

### **PR Type**
Bug fix


___

### **Description**
- Remove blocking patterns from .dockerignore file

- Allow docker-compose and Dockerfile files into Docker image

- Fix test failures requiring docker-compose.integration.yml availability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[".dockerignore blocking patterns"] -- "Remove docker-compose*.yml and Dockerfile*" --> B["Files copied into Docker image"]
  B --> C["Tests can access docker-compose.integration.yml"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.dockerignore</strong><dd><code>Remove docker-compose and Dockerfile blocking patterns</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.dockerignore

<ul><li>Removed <code>docker-compose*.yml</code> pattern that was blocking docker-compose <br>configuration files<br> <li> Removed <code>Dockerfile*</code> pattern that was blocking Dockerfile variants<br> <li> Allows COPY commands in Dockerfile to successfully include these files <br>in the image</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/figure-collector-integration-tests/pull/7/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

